### PR TITLE
Replace cegis, dependabot updates, http/https configuration change

### DIFF
--- a/config.app.js
+++ b/config.app.js
@@ -1,7 +1,6 @@
 
-const S_DATA_HOST = process.env.DEPLOYMENT_HOST || 'http://gnis-ld.org';
+const P_DATA_URI = process.env.DEPLOYMENT_HOST || 'http://gnis-ld.org';
 
-const P_DATA_URI = `${S_DATA_HOST}`;
 const P_RDF_URI = `${P_DATA_URI}/lod`;
 const P_GEOM_URI = `${P_DATA_URI}/geometry`;
 

--- a/config.app.js
+++ b/config.app.js
@@ -1,8 +1,7 @@
 
-const S_DATA_HOST = 'stage.gnis-ld.org';
-// const S_DATA_PATH = process.env.USGS_DATA_PATH || 'stage.gnis-ld.org';
+const S_DATA_HOST = process.env.DEPLOYMENT_HOST || 'http://gnis-ld.org';
 
-const P_DATA_URI = `https://${S_DATA_HOST}`;
+const P_DATA_URI = `${S_DATA_HOST}`;
 const P_RDF_URI = `${P_DATA_URI}/lod`;
 const P_GEOM_URI = `${P_DATA_URI}/geometry`;
 
@@ -20,15 +19,12 @@ module.exports = {
 		geosparql: 'http://www.opengis.net/ont/geosparql#',
 		ago: 'http://awesemantic-geo.link/ontology/',
 		geonames: 'http://sws.geonames.org/',
-
 		usgs: `${P_RDF_URI}/usgs/ontology/`,
 		gnis: `${P_RDF_URI}/gnis/ontology/`,
 		gnisf: `${P_RDF_URI}/gnis/feature/`,
 		'gnisf-alias': `${P_RDF_URI}/gnis/feature-alias/`,
 		nhd: `${P_RDF_URI}/nhd/ontology/`,
 		nhdf: `${P_RDF_URI}/nhd/feature/`,
-		cegis: `${P_RDF_URI}/cegis/ontology/`,
-		cegisf: `${P_RDF_URI}/cegis/feature/`,
 		'usgeo-point': `${P_GEOM_URI}/point/`,
 		'usgeo-multipoint': `${P_GEOM_URI}/multipoint/`,
 		'usgeo-linestring': `${P_GEOM_URI}/linestring/`,

--- a/lib/gnis/features.js
+++ b/lib/gnis/features.js
@@ -89,7 +89,7 @@ triplify('./data/input/gnis/features.zip', {
 			object: (s) => {
 				s = s.replace(/ /g, '');
 				if(s in H_GNIS_CLASS_MAPPINGS) s = H_GNIS_CLASS_MAPPINGS[s];
-				return 'cegis:'+s;
+				return 'usgs:'+s;
 			},
 		},
 		state_alpha: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -561,6 +561,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
+    },
     "decompress-zip": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.2.tgz",
@@ -694,6 +699,15 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-blob": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
+      "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -723,6 +737,14 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
       }
     },
     "fs-constants": {
@@ -995,10 +1017,20 @@
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "optional": true
     },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.1.tgz",
+      "integrity": "sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==",
+      "requires": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.3",
+        "formdata-polyfill": "^4.0.10"
+      }
     },
     "nopt": {
       "version": "3.0.6",
@@ -1490,6 +1522,11 @@
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
       "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
     },
     "worker": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,9 +114,9 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "ajv": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
-      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -706,9 +706,9 @@
       "integrity": "sha1-ZQnwEmr0wXhVHPqZOU4DLhOk1W4="
     },
     "follow-redirects": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
-      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
     "forever-agent": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "csv-parse": "^4.8.5",
     "fs-extra": "^10.0.0",
     "mkdirp": "^1.0.3",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^3.1.1",
     "ogr2ogr": "^1.5.0",
     "pg": "^8.0.0",
     "pg-cursor": "^2.1.5",


### PR DESCRIPTION
This is a small PR that includes a few dependabot updates and replaces the _cegis_ ontology references with _usgs_. The changes in this PR are currently deployed on stage.gnis-ld.org. A small change was made to the config to

1. Include the http prefix if no environmental variable is specified
2. Remove the hardcoded http/https prefix to allow developers to set it in the k8/docker deployment file

The attached screenshot shows that the feature types are now usgs instead of cegis.

<img width="1186" alt="Screen Shot 2022-02-24 at 6 22 25 PM" src="https://user-images.githubusercontent.com/9289652/155641700-afa9c43b-f081-4de2-a030-4dc9a3a40455.png">

I have a small change to make on the front end-the yasgui editor is missing the `stage.` prefix in the pre-canned queries but the triples should be okay.
