### PR TITLE
2.1.0

### DIFF
--- a/lib/gnis/features.js
+++ b/lib/gnis/features.js
@@ -126,7 +126,7 @@ triplify('./data/input/gnis/features.zip', {
 
 				// geometry uri
 				return {
-					'ago:geometry': [`>${p_geom_iri}`],
+					'geosparql:hasGeometry': [`>${p_geom_iri}`],
 				};
 			}
 		},

--- a/lib/nhd/triplifier.js
+++ b/lib/nhd/triplifier.js
@@ -177,7 +177,7 @@ class Triplifier_Feature extends Triplifier {
 		let sct_geometry = `usgeo-${hpg_type.lower}:${sct_self.replace(':', '.')}`;
 
 		// store geometry to feature
-		h_pairs['ago:geometry'] = sct_geometry;
+		h_pairs['geosparql:hasGeometry'] = sct_geometry;
 
 		// add triples about geometry
 		let h_geom = h_triples[sct_geometry] = {
@@ -197,10 +197,10 @@ class Triplifier_Feature extends Triplifier {
 		else {
 			Object.assign(h_geom, {
 				// add centroid
-				'ago:centroid': wkt_to_ct(h_row.wkt_centroid),
+				'geosparql:hasCentroid': wkt_to_ct(h_row.wkt_centroid),
 
 				// add bounding box
-				'ago:boundingBox': wkt_to_ct(h_row.wkt_bounding_box),
+				'geosparql:hasBoundingBox': wkt_to_ct(h_row.wkt_bounding_box),
 
 				// point count
 				'ago:pointCount': factory.integer(h_row.n_points),
@@ -209,17 +209,17 @@ class Triplifier_Feature extends Triplifier {
 
 		// linear
 		if(hpg_type.linear) {
-			h_geom['ago:length'] = qty_to_wo(h_row.x_length, 'M');
+			h_geom['geosparql:hasLength'] = qty_to_wo(h_row.x_length, 'M');
 		}
 
 		// areal
 		if(hpg_type.areal) {
 			Object.assign(h_geom, {
-				// area
-				'ago:area': qty_to_wo(h_row.x_area, 'M2'),
+				// area in square meters
+				'geosparql:hasMetricArea': qty_to_wo(h_row.x_area, 'M2'),
 
-				// perimeter
-				'ago:perimeter': qty_to_wo(h_row.x_perimeter, 'M'),
+				// perimeter in meters
+				'geosparql:hasMetricPerimeterLength': qty_to_wo(h_row.x_perimeter, 'M'),
 
 				// number of rings
 				'ago:ringCount': factory.integer(h_row.n_rings),

--- a/package-lock.json
+++ b/package-lock.json
@@ -225,9 +225,9 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "requires": {
         "lodash": "^4.17.14"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -986,9 +986,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "1.0.3",


### PR DESCRIPTION
This PR contains the features that will make up the 2.1.0 release. It includes a few dependency updates and a partial replacement of the ago ontology.


To test:
1. Visit the [stage site](https://stage.gnis-ld.org/queries)
2. Open a new query tab and run `Query 1` (below)
3. Confirm 10 results
4. Run `Query 2` (below)
5. Confirm that there are no longer any results



### Query 1
This query gets geometries with the geosparql:hasGeometry predicate.
```
PREFIX geosparql: <http://www.opengis.net/ont/geosparql#>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
SELECT * WHERE {
  ?sub geosparql:hasGeometry ?obj .
} LIMIT 10
```

### Query 2
This looks for any triples with the ago:geometry as the predicate. This shouldn't return any results.
```
PREFIX ago: <http://awesemantic-geo.link/ontology/>
SELECT * WHERE {
  ?sub ago:geometry ?obj .
} LIMIT 10
```